### PR TITLE
Refactored options for transactions method in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Replace 01/01/1980 with your actual birthday.
 
 #### Transactions with date range
 
-    $ bankscrap transactions YourBank --user YOUR_BANK_USER --password YOUR_BANK_PASSWORD --extra=from:01-01-2015 to:01-02-2015
+    $ bankscrap transactions YourBank --user YOUR_BANK_USER --password YOUR_BANK_PASSWORD --from 01-01-2015 --to 01-02-2015
 
 ---
 

--- a/lib/bankscrap/cli.rb
+++ b/lib/bankscrap/cli.rb
@@ -33,12 +33,8 @@ module Bankscrap
     def transactions(bank, iban = nil)
       assign_shared_options
 
-      begin
-        start_date = options.key?("from") ? Date.strptime(options[:from], '%d-%m-%Y') : nil
-        end_date = options.key?("to") ? Date.strptime(options[:to], '%d-%m-%Y') : nil
-      rescue ArgumentError => e
-        say 'Invalid date format. Correct format d-m-Y', :red
-      end
+      start_date = options.key?("from") ? Date.strptime(options[:from], '%d-%m-%Y') : nil
+      end_date = options.key?("to") ? Date.strptime(options[:to], '%d-%m-%Y') : nil
 
       initialize_client_for(bank)
 
@@ -60,6 +56,8 @@ module Bankscrap
       transactions.each do |transaction|
         say transaction.to_s, (transaction.amount > Money.new(0) ? :green : :red)
       end
+    rescue ArgumentError
+      say 'Invalid date format. Correct format d-m-Y (eg: 31-12-2016)', :red
     end
 
     private

--- a/lib/bankscrap/cli.rb
+++ b/lib/bankscrap/cli.rb
@@ -29,13 +29,14 @@ module Bankscrap
 
     desc 'transactions BANK', "get account's transactions"
     shared_options
+    options from: :string, to: :string
     def transactions(bank, iban = nil)
       assign_shared_options
 
       begin
-        start_date = @extra_args.key?('from') ? Date.strptime(@extra_args['from'], '%d-%m-%Y') : nil
-        end_date = @extra_args.key?('to') ? Date.strptime(@extra_args['to'], '%d-%m-%Y') : nil
-      rescue ArgumentError
+        start_date = options.key?("from") ? Date.strptime(options[:from], '%d-%m-%Y') : nil
+        end_date = options.key?("to") ? Date.strptime(options[:to], '%d-%m-%Y') : nil
+      rescue ArgumentError => e
         say 'Invalid date format. Correct format d-m-Y', :red
       end
 


### PR DESCRIPTION
It didn't make sense to pass `from` and `to` as part of the `--extra` arg. Now these are two optionals arguments for `transactions` in the CLI.