### PR TITLE
Added generator for bank adapters

### DIFF
--- a/bankscrap.gemspec
+++ b/bankscrap.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/bank-scrap/bank_scrap'
   spec.license       = 'MIT'
 
-  spec.files         = Dir['README.md', 'lib/**/{*,.[a-z]*}']
+  spec.files         = Dir['README.md', 'lib/**/{*,.[a-z]*}', 'generators/**/{*,.[a-z]*}']
   spec.executables << 'bankscrap'
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']

--- a/generators/adapter_generator.rb
+++ b/generators/adapter_generator.rb
@@ -1,0 +1,41 @@
+module Bankscrap
+  class AdapterGenerator < Thor::Group
+    include Thor::Actions
+
+    argument :bank_name
+
+    def self.source_root
+       File.join(File.dirname(__FILE__), 'templates')
+    end
+
+    def generate
+      empty_directory(gem_name)
+      self.destination_root = File.expand_path('.', gem_name)
+
+      directory '.'
+      say ""
+      say "Great! Now you can start implementing your bank's adapter for Bankscrap.", :yellow
+      say ""
+      say "To get started take a look to:", :yellow
+      say "#{destination_root}/#{gem_name}.rb", :yellow
+      say ""
+      say "If you need help you join our Slack chat room. Click the Slack badge on Github:", :yellow
+      say "https://github.com/bankscrap/bankscrap", :yellow
+
+
+    end
+
+
+    protected
+    def bank_name_dasherized
+      @bank_name_dasherized ||= bank_name.underscore.dasherize
+    end
+    def gem_name
+      @gem_name ||= 'bankscrap-' + bank_name_dasherized
+    end
+
+    def module_name
+      @module_name ||= bank_name
+    end
+  end
+end

--- a/generators/adapter_generator.rb
+++ b/generators/adapter_generator.rb
@@ -18,12 +18,12 @@ module Bankscrap
       say "To get started take a look to:", :yellow
       say "#{destination_root}/#{gem_name}.rb", :yellow
       say ""
-      say "If you need help you join our Slack chat room. Click the Slack badge on Github:", :yellow
+      say "If you need help you can join our Slack chat room. Click the Slack badge on Github:", :yellow
       say "https://github.com/bankscrap/bankscrap", :yellow
     end
 
     protected
-    
+
     def bank_name_dasherized
       @bank_name_dasherized ||= bank_name.underscore.dasherize
     end

--- a/generators/adapter_generator.rb
+++ b/generators/adapter_generator.rb
@@ -9,7 +9,6 @@ module Bankscrap
     end
 
     def generate
-      empty_directory(gem_name)
       self.destination_root = File.expand_path('.', gem_name)
 
       directory '.'

--- a/generators/adapter_generator.rb
+++ b/generators/adapter_generator.rb
@@ -10,8 +10,8 @@ module Bankscrap
 
     def generate
       self.destination_root = File.expand_path('.', gem_name)
-
       directory '.'
+
       say ""
       say "Great! Now you can start implementing your bank's adapter for Bankscrap.", :yellow
       say ""
@@ -20,12 +20,10 @@ module Bankscrap
       say ""
       say "If you need help you join our Slack chat room. Click the Slack badge on Github:", :yellow
       say "https://github.com/bankscrap/bankscrap", :yellow
-
-
     end
 
-
     protected
+    
     def bank_name_dasherized
       @bank_name_dasherized ||= bank_name.underscore.dasherize
     end

--- a/generators/templates/%gem_name%.gemspec.tt
+++ b/generators/templates/%gem_name%.gemspec.tt
@@ -1,0 +1,23 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'bankscrap/<%= bank_name_dasherized %>/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = '<%= gem_name %>'
+  spec.version       = Bankscrap::<%= module_name %>::VERSION
+  spec.authors       = ['Your Name']
+  spec.email         = ['your@email.com']
+  spec.summary       = '<%= bank_name %> adapter for Bankscrap'
+  spec.homepage      = ''
+  spec.license       = 'MIT'
+
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ['lib']
+
+  spec.add_runtime_dependency 'bankscrap'
+  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'rake', '~> 10.0'
+end

--- a/generators/templates/Gemfile.tt
+++ b/generators/templates/Gemfile.tt
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in <%= gem_name %>.gemspec
+gemspec

--- a/generators/templates/LICENSE.txt
+++ b/generators/templates/LICENSE.txt
@@ -1,0 +1,20 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/generators/templates/README.md.tt
+++ b/generators/templates/README.md.tt
@@ -1,0 +1,56 @@
+# Bankscrap::<%= module_name %>
+
+Bankscrap adapter for <%= bank_name %>
+
+**TODO**: write a proper description for your adapter.
+
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem '<%= gem_name %>'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install <%= gem_name %>
+
+## Usage
+
+### From terminal
+#### Bank account balance
+
+    $ bankscrap balance <%= module_name %> --user YOUR_USER --password YOUR_PASSWORD --extra=company_code:YOUR_COMPANY_CODE
+
+
+#### Transactions
+
+    $ bankscrap transactions <%= module_name %> --user YOUR_USER --password YOUR_PASSWORD --extra=company_code:YOUR_COMPANY_CODE
+
+---
+
+For more details on usage instructions please read [Bankscrap readme](https://github.com/bankscrap/bankscrap/#usage).
+
+### From Ruby code
+
+**TODO**: check if your bank adapter needs more extra_args for the initializer.
+
+```ruby
+require '<%= gem_name %>'
+<%= bank_name.underscore %> = Bankscrap::<%= module_name %>::Bank.new(YOUR_USER, YOUR_PASSWORD, extra_args: {arg: EXTRA_ARG_1})
+```
+
+
+## Contributing
+
+1. Fork it ( https://github.com/bankscrap/<%= gem_name %>/fork )
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create a new Pull Request

--- a/generators/templates/Rakefile.tt
+++ b/generators/templates/Rakefile.tt
@@ -1,0 +1,1 @@
+require 'bundler/gem_tasks'

--- a/generators/templates/lib/%gem_name%.rb.tt
+++ b/generators/templates/lib/%gem_name%.rb.tt
@@ -1,0 +1,2 @@
+require_relative 'bankscrap/<%= bank_name_dasherized %>/bank'
+require_relative 'bankscrap/<%= bank_name_dasherized %>/version'

--- a/generators/templates/lib/bankscrap/%bank_name_dasherized%/bank.rb.tt
+++ b/generators/templates/lib/bankscrap/%bank_name_dasherized%/bank.rb.tt
@@ -1,0 +1,91 @@
+require 'bankscrap'
+require 'securerandom'
+
+module Bankscrap
+  module <%= module_name %>
+    class Bank < ::Bankscrap::Bank
+
+      # Define the endpoints for the Bank API here
+      # BASE_ENDPOINT         = 'https://api.mybank.com'.freeze
+      # LOGIN_ENDPOINT        = '/login'.freeze
+      # ACCOUNTS_ENDPOINT     = '/accounts'.freeze
+      # TRANSACTIONS_ENDPOINT = '/transactions'.freeze
+
+      def initialize(user, password, log: false, debug: false, extra_args: nil)
+        @user = user
+        @password = password
+        @log = log
+        @debug = debug
+        # @extra_arg1 = extra_args.with_indifferent_access['extra_arg1']
+
+        initialize_connection
+
+        # Optional Custom headers
+        # user_agent = SecureRandom.hex(32).upcase + ';Android;LGE;Nexus 5;1080x1776;Android;5.1.1;BMES;4.4;xxhd'
+        # add_headers(
+        #   'User-Agent' => user_agent
+        # )
+
+        login
+        super
+      end
+
+      # Fetch all the accounts for the given user
+      #
+      # Should returns an array of Bankscrap::Account objects
+      def fetch_accounts
+        # Example if the API expects a JSON POST request
+        # response = post(BASE_ENDPOINT + ACCOUNTS_ENDPOINT, fields: {}.to_json)
+        # json = JSON.parse(response)
+        # json['accounts'].map { |data| build_account(data) }
+      end
+
+      # Fetch transactions for the given account.
+      #
+      # Account should be a Bankscrap::Account object
+      # Should returns an array of Bankscrap::Account objects
+      def fetch_transactions_for(account, start_date: Date.today - 1.month, end_date: Date.today)
+        # Example if the API expects a JSON POST request
+        # response = post(BASE_ENDPOINT + TRANSACTIONS_ENDPOINT, fields: {}.to_json)
+        # json = JSON.parse(response)
+        # json['transactions'].map { |data| build_transaction(data) }
+      end
+
+      private
+
+      # First request to login
+      def login
+        # Example if the API expects a JSON POST request
+        # params = { user: @user, password: @password }
+        # post(BASE_ENDPOINT + LOGIN_ENDPOINT, fields: params.to_json)
+      end
+
+      # Build an Account object from API data
+      def build_account(data)
+        Account.new(
+          bank: self,
+          id: REPLACE_ME,
+          name: REPLACE_ME,
+          available_balance: REPLACE_ME,
+          balance: REPLACE_ME,
+          currency: REPLACE_ME,
+          iban: REPLACE_ME,
+          description: REPLACE_ME
+        )
+      end
+
+      # Build a transaction object from API data
+      def build_transaction(data, account)
+        Transaction.new(
+          account: account,
+          id: REPLACE_ME,
+          amount: REPLACE_ME,
+          description: REPLACE_ME,
+          effective_date: REPLACE_ME,
+          currency: REPLACE_ME, # Should be a Money object
+          balance: REPLACE_ME   # Should be a Money object
+        )
+      end
+    end
+  end
+end

--- a/generators/templates/lib/bankscrap/%bank_name_dasherized%/version.rb.tt
+++ b/generators/templates/lib/bankscrap/%bank_name_dasherized%/version.rb.tt
@@ -1,0 +1,5 @@
+module Bankscrap
+  module <%= bank_name %>
+    VERSION = '1.0.0'.freeze
+  end
+end

--- a/lib/bankscrap/cli.rb
+++ b/lib/bankscrap/cli.rb
@@ -1,5 +1,9 @@
 require 'thor'
 require 'active_support/core_ext/string'
+Dir[File.expand_path("../../..", __FILE__) + "/generators/*.rb"].each do |generator|
+  require generator
+end
+
 
 module Bankscrap
   class CLI < Thor
@@ -62,6 +66,10 @@ module Bankscrap
         say transaction.to_s, (transaction.amount > Money.new(0) ? :green : :red)
       end
     end
+
+
+    register(Bankscrap::AdapterGenerator, "generate_adapter", "generate_adapter MyBankName", 
+      "generates a template for a new Bankscrap bank adapter")
 
     private
 


### PR DESCRIPTION
The idea is to provide a generator for new bank adapters so that more people can start contributing to the project.

Usage:

```
$ bankscrap generate_adapter MyCoolBank

      create  bankscrap-my-cool-bank
      create  bankscrap-my-cool-bank.gemspec
      create  Gemfile
      create  LICENSE.txt
      create  README.md
      create  Rakefile
      create  lib/bankscrap-my-cool-bank.rb
      create  lib/bankscrap/my-cool-bank/bank.rb
      create  lib/bankscrap/my-cool-bank/version.rb

Great! Now you can start implementing your bank's adapter for Bankscrap.

To get started take a look to:
/Users/javi/bankscrap/bankscrap-my-cool-bank/bankscrap-my-cool-bank.rb

If you need help you can join our Slack chat room. Click the Slack badge on Github:
https://github.com/bankscrap/bankscrap
```

References used to implement this:
* [Thor documentation](http://www.rubydoc.info/github/wycats/thor/master/Thor/Actions)
* [ActiveMerchant generator](https://github.com/activemerchant/active_merchant/tree/master/generators)
