### PR TITLE
Bank initialize and configuration refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,42 +59,47 @@ Note that you only need to install the gem for your selected bank – the main g
 
 ###### BBVA
 
-    $ bankscrap balance YourBank --user YOUR_BANK_USER --password YOUR_BANK_PASSWORD
+    $ bankscrap balance YourBank --credentials=user:YOUR_BANK_USER password:YOUR_BANK_PASSWORD
 
 ###### ING Direct
 ING needs one more argument: your birthday.
 
-    $ bankscrap balance ING --user YOUR_DNI --password YOUR_PASSWORD --extra=birthday:01/01/1980
+    $ bankscrap balance ING --credentials=user:YOUR_DNI password:YOUR_BANK_PASSWORD birthday:01/01/1980
 
 Replace 01/01/1980 with your actual birthday.
 
 #### Transactions for last 30 days
 ###### BBVA
 
-    $ bankscrap transactions BBVA --user YOUR_BBVA_USER --password YOUR_BBVA_PASSWORD
+    $ bankscrap transactions BBVA --credentials=user:YOUR_BANK_USER password:YOUR_BANK_PASSWORD
 
 ###### ING Direct
 
-    $ bankscrap transactions ING --user YOUR_DNI --password YOUR_PASSWORD --extra=birthday:01/01/1980
+    $ bankscrap transactions ING --credentials=user:YOUR_DNI password:YOUR_BANK_PASSWORD birthday:01/01/1980
 
 #### Transactions with date range
 
-    $ bankscrap transactions YourBank --user YOUR_BANK_USER --password YOUR_BANK_PASSWORD --from 01-01-2015 --to 01-02-2015
+    $ bankscrap transactions YourBank --credentials=user:YOUR_BANK_USER password:YOUR_BANK_PASSWORD --from 01-01-2015 --to 01-02-2015
 
 ---
 
 By default it will use your first bank account, if you want to fetch transactions for a different account you can use this syntax:
 
-    $ bankscrap transactions YourBank --iban "your_iban" --user YOUR_DNI --password YOUR_PASSWORD
+    $ bankscrap transactions YourBank --iban "your_iban" --credentials=user:YOUR_BANK_USER password:YOUR_BANK_PASSWORD 
 
 If you don't want to pass your user and password everytime you can define them in your .bash_profile by adding:
 
-    export BANK_SCRAP_USER=YOUR_BANK_USER
-    export BANK_SCRAP_PASSWORD=YOUR_BANK_PASSWORD
+    export BANKSCRAP_[BANK_NAME]_USER=YOUR_BANK_USER
+    export BANKSCRAP_[BANK_NAME]_PASSWORD=YOUR_BANK_USER
+    export BANKSCRAP_[BANK_NAME]_ANY_OTHER_CREDENTIAL=ANY_OTHER_CREDENTIAL
+
+eg: 
+    export BANKSCRAP_BBVA_NET_CASH_USER=YOUR_BANK_USER
+
 
 #### Export transactions to CSV
 
-    $ bankscrap transactions YourBank --user YOUR_BANK_USER --password YOUR_BANK_PASSWORD --format CSV [--output ./my_transactions.csv]
+    $ bankscrap transactions YourBank --credentials=user:YOUR_BANK_USER password:YOUR_BANK_PASSWORD --format CSV [--output ./my_transactions.csv]
 
 Currently only CSV is supported. The output parameter is optional, by default `transactions.csv` is used.
 
@@ -106,7 +111,7 @@ You can also use this gem from your own app as library. To do so first you must 
 ```ruby
 # BBVA
 require 'bankscrap-bbva'
-bbva = Bankscrap::BBVA::Bank.new(YOUR_BBVA_USER, YOUR_BBVA_PASSWORD)
+bbva = Bankscrap::BBVA::Bank.new(user: YOUR_BBVA_USER, password: YOUR_BBVA_PASSWORD)
 
 # ING
 require 'bankscrap-ing'

--- a/bankscrap.gemspec
+++ b/bankscrap.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake',    '~> 10.0'
   spec.add_development_dependency 'byebug',  '~> 3.5', '>= 3.5.1'
   spec.add_development_dependency 'rubocop', '~> 0.39.0'
+  spec.add_development_dependency 'rspec',   '~> 3.4.0'
 
   spec.add_dependency 'thor',          '~> 0.19'
   spec.add_dependency 'mechanize',     '~> 2.7.4'

--- a/generators/templates/README.md.tt
+++ b/generators/templates/README.md.tt
@@ -26,12 +26,12 @@ Or install it yourself as:
 ### From terminal
 #### Bank account balance
 
-    $ bankscrap balance <%= module_name %> --user YOUR_USER --password YOUR_PASSWORD --extra=company_code:YOUR_COMPANY_CODE
+    $ bankscrap balance <%= module_name %> --credentials=user:YOUR_USER --password:YOUR_PASSWORD --any_other_credential:ANY_OTHER_CREDENTIAL
 
 
 #### Transactions
 
-    $ bankscrap transactions <%= module_name %> --user YOUR_USER --password YOUR_PASSWORD --extra=company_code:YOUR_COMPANY_CODE
+    $ bankscrap transactions <%= module_name %> --credentials=user:YOUR_USER --password:YOUR_PASSWORD --any_other_credential:ANY_OTHER_CREDENTIAL
 
 ---
 
@@ -39,11 +39,9 @@ For more details on usage instructions please read [Bankscrap readme](https://gi
 
 ### From Ruby code
 
-**TODO**: check if your bank adapter needs more extra_args for the initializer.
-
 ```ruby
 require '<%= gem_name %>'
-<%= bank_name.underscore %> = Bankscrap::<%= module_name %>::Bank.new(YOUR_USER, YOUR_PASSWORD, extra_args: {arg: EXTRA_ARG_1})
+<%= bank_name.underscore %> = Bankscrap::<%= module_name %>::Bank.new(user: YOUR_USER, password: YOUR_PASSWORD, any_other_credential: ANY_OTHER_CREDENTIAL)
 ```
 
 

--- a/generators/templates/lib/bankscrap/%bank_name_dasherized%/bank.rb.tt
+++ b/generators/templates/lib/bankscrap/%bank_name_dasherized%/bank.rb.tt
@@ -11,23 +11,20 @@ module Bankscrap
       # ACCOUNTS_ENDPOINT     = '/accounts'.freeze
       # TRANSACTIONS_ENDPOINT = '/transactions'.freeze
 
-      def initialize(user, password, log: false, debug: false, extra_args: nil)
-        @user = user
-        @password = password
-        @log = log
-        @debug = debug
-        # @extra_arg1 = extra_args.with_indifferent_access['extra_arg1']
+      # TODO: change this for the proper credentials required in your adapter.
+      # It can be anything (user, birthday, ID, whatever you need).
+      REQUIRED_CREDENTIALS  = [:user, :password, :any_other_credential]
 
-        initialize_connection
+      def initialize(credentials = {})
+        super do
+          # Here you can do further processing of the received credentials
+          # or add custom headers to the HTTP client
 
-        # Optional Custom headers
-        # user_agent = SecureRandom.hex(32).upcase + ';Android;LGE;Nexus 5;1080x1776;Android;5.1.1;BMES;4.4;xxhd'
-        # add_headers(
-        #   'User-Agent' => user_agent
-        # )
-
-        login
-        super
+          # user_agent = SecureRandom.hex(32).upcase + ';Android;LGE;Nexus 5;1080x1776;Android;5.1.1;BMES;4.4;xxhd'
+          # add_headers(
+          #   'User-Agent' => user_agent
+          # )
+        end
       end
 
       # Fetch all the accounts for the given user

--- a/lib/bankscrap.rb
+++ b/lib/bankscrap.rb
@@ -10,3 +10,15 @@ require_relative 'bankscrap/account'
 require_relative 'bankscrap/investment'
 require_relative 'bankscrap/transaction'
 require_relative 'bankscrap/exporters/csv'
+
+module Bankscrap
+  class << self
+    attr_accessor :log
+    attr_accessor :debug
+    attr_accessor :proxy
+  end
+
+  self.log = false
+  self.debug = false
+  # self.proxy = {host: 'localhost', port: 8888}
+end

--- a/lib/bankscrap.rb
+++ b/lib/bankscrap.rb
@@ -18,6 +18,13 @@ module Bankscrap
     attr_accessor :proxy
   end
 
+  class NotMoneyObjectError < TypeError
+    def initialize(attribute)
+      super("#{attribute} should be a Money object")
+    end
+  end
+
+
   self.log = false
   self.debug = false
   # self.proxy = {host: 'localhost', port: 8888}

--- a/lib/bankscrap/account.rb
+++ b/lib/bankscrap/account.rb
@@ -1,10 +1,18 @@
 module Bankscrap
   class Account
     include Utils::Inspectable
+    
+    class InvalidBalance < ArgumentError; end
 
-    attr_accessor :bank, :id, :name, :balance, :currency, :available_balance, :description, :transactions, :iban, :bic
+    attr_accessor :bank, :id, :name, :balance, 
+                  :available_balance, :description, 
+                  :transactions, :iban, :bic
 
     def initialize(params = {})
+      unless params[:balance].is_a?(Money) && params[:available_balance].is_a?(Money)
+        raise InvalidBalance.new('balance and available_balance should be Money objects')
+      end
+
       params.each { |key, value| send "#{key}=", value }
     end
 
@@ -14,6 +22,10 @@ module Bankscrap
 
     def fetch_transactions(start_date: Date.today - 2.years, end_date: Date.today)
       bank.fetch_transactions_for(self, start_date: start_date, end_date: end_date)
+    end
+
+    def currency
+      balance.try(:currency)
     end
 
     private

--- a/lib/bankscrap/account.rb
+++ b/lib/bankscrap/account.rb
@@ -2,16 +2,13 @@ module Bankscrap
   class Account
     include Utils::Inspectable
     
-    class InvalidBalance < ArgumentError; end
-
     attr_accessor :bank, :id, :name, :balance, 
                   :available_balance, :description, 
                   :transactions, :iban, :bic
 
     def initialize(params = {})
-      unless params[:balance].is_a?(Money) && params[:available_balance].is_a?(Money)
-        raise InvalidBalance.new('balance and available_balance should be Money objects')
-      end
+      raise NotMoneyObjectError.new(:balance) unless params[:balance].is_a?(Money)
+      raise NotMoneyObjectError.new(:available_balance) unless params[:available_balance].is_a?(Money)
 
       params.each { |key, value| send "#{key}=", value }
     end
@@ -31,7 +28,7 @@ module Bankscrap
     private
 
     def inspect_attributes
-      %i(id name balance currency available_balance description iban bic)
+      %i(id name balance available_balance description iban bic)
     end
   end
 end

--- a/lib/bankscrap/cli.rb
+++ b/lib/bankscrap/cli.rb
@@ -67,15 +67,17 @@ module Bankscrap
     private
 
     def assign_shared_options
-      @credentials       = options[:credentials]
-      @iban       = options[:iban]
-      @log        = options[:log]
-      @debug      = options[:debug]
+      @credentials  = options[:credentials]
+      @iban         = options[:iban]
+      @log          = options[:log]
+      @debug        = options[:debug]
     end
 
     def initialize_client_for(bank_name)
       bank_class = find_bank_class_for(bank_name)
-      @client = bank_class.new(@credentials, log: @log, debug: @debug)
+      Bankscrap.log = @log
+      Bankscrap.debug = @debug
+      @client = bank_class.new(@credentials)
     end
 
     def find_bank_class_for(bank_name)

--- a/lib/bankscrap/cli.rb
+++ b/lib/bankscrap/cli.rb
@@ -24,7 +24,10 @@ module Bankscrap
 
       @client.accounts.each do |account|
         say "Account: #{account.description} (#{account.iban})", :cyan
-        say "Balance: #{account.balance}", :green
+        say "Balance: #{account.balance.format}", :green
+        if account.balance != account.available_balance
+          say "Available: #{account.available_balance.format}", :yellow
+        end
       end
     end
 

--- a/lib/bankscrap/cli.rb
+++ b/lib/bankscrap/cli.rb
@@ -8,19 +8,12 @@ end
 module Bankscrap
   class CLI < Thor
     def self.shared_options
-      option :user,     default: ENV['BANKSCRAP_USER']
-      option :password, default: ENV['BANKSCRAP_PASSWORD']
-      option :log,      default: false
-      option :debug,    default: false
-      option :iban,     default: nil
-
+      option :credentials, default: {}, type: :hash
+      option :log,         default: false
+      option :debug,       default: false
+      option :iban,        default: nil
       option :format
       option :output
-
-      # Some bank needs more input, like birthday, this would go here
-      # Usage:
-      # bankscrap balance BankName --extra=birthday:01/12/1980
-      option :extra, type: :hash, default: {}
     end
 
     desc 'balance BankName', "get accounts' balance"
@@ -74,17 +67,15 @@ module Bankscrap
     private
 
     def assign_shared_options
-      @user       = options[:user]
-      @password   = options[:password]
+      @credentials       = options[:credentials]
       @iban       = options[:iban]
       @log        = options[:log]
       @debug      = options[:debug]
-      @extra_args = options[:extra]
     end
 
     def initialize_client_for(bank_name)
       bank_class = find_bank_class_for(bank_name)
-      @client = bank_class.new(@user, @password, log: @log, debug: @debug, extra_args: @extra_args)
+      @client = bank_class.new(@credentials, log: @log, debug: @debug)
     end
 
     def find_bank_class_for(bank_name)

--- a/lib/bankscrap/transaction.rb
+++ b/lib/bankscrap/transaction.rb
@@ -2,11 +2,16 @@ module Bankscrap
   class Transaction
     include Utils::Inspectable
 
-    attr_accessor :id, :amount, :currency,
-                  :effective_date, :description,
+    class InvalidAmount < ArgumentError; end
+
+    attr_accessor :id, :amount, :description,
                   :balance, :account
 
     def initialize(params = {})
+      unless params[:amount].is_a?(Money)
+        raise InvalidAmount.new('amount should be a Money object')
+      end
+
       params.each { |key, value| send "#{key}=", value }
     end
 
@@ -16,6 +21,10 @@ module Bankscrap
 
     def to_a
       [effective_date.strftime('%d/%m/%Y'), description, amount]
+    end
+
+    def currency
+      amount.currency
     end
 
     private

--- a/lib/bankscrap/transaction.rb
+++ b/lib/bankscrap/transaction.rb
@@ -2,15 +2,11 @@ module Bankscrap
   class Transaction
     include Utils::Inspectable
 
-    class InvalidAmount < ArgumentError; end
-
     attr_accessor :id, :amount, :description,
                   :balance, :account
 
     def initialize(params = {})
-      unless params[:amount].is_a?(Money)
-        raise InvalidAmount.new('amount should be a Money object')
-      end
+      raise NotMoneyObjectError.new(:amount) unless params[:amount].is_a?(Money)
 
       params.each { |key, value| send "#{key}=", value }
     end
@@ -30,11 +26,7 @@ module Bankscrap
     private
 
     def inspect_attributes
-      [
-        :id, :amount, :currency,
-        :effective_date, :description,
-        :balance
-      ]
+      [ :id, :amount, :effective_date, :description, :balance ]
     end
   end
 end

--- a/lib/bankscrap/transaction.rb
+++ b/lib/bankscrap/transaction.rb
@@ -2,7 +2,7 @@ module Bankscrap
   class Transaction
     include Utils::Inspectable
 
-    attr_accessor :id, :amount, :description, :effective_date
+    attr_accessor :id, :amount, :description, :effective_date,
                   :balance, :account
 
     def initialize(params = {})

--- a/lib/bankscrap/transaction.rb
+++ b/lib/bankscrap/transaction.rb
@@ -2,7 +2,7 @@ module Bankscrap
   class Transaction
     include Utils::Inspectable
 
-    attr_accessor :id, :amount, :description,
+    attr_accessor :id, :amount, :description, :effective_date
                   :balance, :account
 
     def initialize(params = {})

--- a/lib/bankscrap/version.rb
+++ b/lib/bankscrap/version.rb
@@ -1,3 +1,3 @@
 module Bankscrap
-  VERSION = '1.0.4'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -19,7 +19,7 @@ describe Bankscrap::Account do
       subject { Bankscrap::Account.new({balance: 100}) }
 
       it 'raise an exception' do
-        expect{subject}.to raise_error(Bankscrap::Account::InvalidBalance)
+        expect{subject}.to raise_error(Bankscrap::NotMoneyObjectError)
       end
     end
   end

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Bankscrap::Account do
+
+  describe '#initialize' do
+    context 'the received balance is a Money object' do
+      subject do
+        Bankscrap::Account.new(
+          balance: Money.new(1000, 'EUR'), 
+          available_balance: Money.new(1000, 'EUR'))
+      end
+
+      it 'raise an exception' do
+        expect{subject}.not_to raise_error
+      end
+    end
+
+    context 'the received balance is not a Money object' do
+      subject { Bankscrap::Account.new({balance: 100}) }
+
+      it 'raise an exception' do
+        expect{subject}.to raise_error(Bankscrap::Account::InvalidBalance)
+      end
+    end
+  end
+end

--- a/spec/bank_spec.rb
+++ b/spec/bank_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe Bankscrap::Bank do
+  before do
+    # Stub login and fetch_accounts methods
+    allow_any_instance_of(Bankscrap::Bank).to receive(:login)
+    allow_any_instance_of(Bankscrap::Bank).to receive(:fetch_accounts)
+  end
+
+  describe '#initialize' do
+    subject { Bankscrap::Bank.new({user: '1234', password: '1234'}) }
+
+    it 'should assign the credentials as instance variables' do
+      expect(subject.instance_variable_get(:@user)).to eq('1234')
+      expect(subject.instance_variable_get(:@password)).to eq('1234')
+    end
+
+    context 'with missing credentials' do
+      subject { Bankscrap::Bank.new({user: '1234'}) }
+      it 'should raise an error' do
+        expect{subject}.to raise_error(Bankscrap::Bank::MissingCredential)
+      end
+    end
+
+    context 'with credentials stored in env vars' do
+      module Bankscrap::TestBank
+        class Bank < Bankscrap::Bank; end
+      end
+      subject { Bankscrap::TestBank::Bank.new }
+
+      before do
+        ENV['BANKSCRAP_TEST_BANK_USER'] = '1234'
+        ENV['BANKSCRAP_TEST_BANK_PASSWORD'] = '1234'
+      end
+
+      it 'should use the credentials from env vars' do
+        expect(subject.instance_variable_get(:@user)).to eq('1234')
+        expect(subject.instance_variable_get(:@password)).to eq('1234')
+      end
+    end
+
+    context 'without a proxy' do
+      before { Bankscrap.proxy = nil }
+
+      it 'does not use any proxy' do
+        expect_any_instance_of(Mechanize).to_not receive(:set_proxy)
+        subject
+      end
+    end
+
+    context 'with a proxy' do
+      before { Bankscrap.proxy = {host: 'localhost', port: 8888} }
+
+      it 'uses the proxy' do
+        expect_any_instance_of(Mechanize).to receive(:set_proxy).with('localhost', 8888)
+        subject
+      end
+    end
+
+    context 'with debug enabled' do
+      before { Bankscrap.debug = true }
+
+      it 'logs http calls to STDOUT' do
+        expect(subject.instance_variable_get(:@http).log).to_not be_nil
+      end
+    end
+
+    context 'with debug disabled' do
+      before { Bankscrap.debug = false }
+
+      it 'logs http calls to STDOUT' do
+        expect(subject.instance_variable_get(:@http).log).to be_nil
+      end
+    end
+  end
+end

--- a/spec/bankscrap_spec.rb
+++ b/spec/bankscrap_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Bankscrap do
+  it 'has a version number' do
+    expect(Bankscrap::VERSION).not_to be nil
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'bankscrap'

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Bankscrap::Transaction do
+
+  describe '#initialize' do
+    context 'the received amount is a Money object' do
+      subject { Bankscrap::Transaction.new({amount: Money.new(1000, 'EUR')}) }
+
+      it 'raise an exception' do
+        expect{subject}.not_to raise_error
+      end
+    end
+
+    context 'the received amount is not a Money object' do
+      subject { Bankscrap::Transaction.new({amount: 100}) }
+
+      it 'raise an exception' do
+        expect{subject}.to raise_error(Bankscrap::Transaction::InvalidAmount)
+      end
+    end
+  end
+end

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -15,7 +15,7 @@ describe Bankscrap::Transaction do
       subject { Bankscrap::Transaction.new({amount: 100}) }
 
       it 'raise an exception' do
-        expect{subject}.to raise_error(Bankscrap::Transaction::InvalidAmount)
+        expect{subject}.to raise_error(Bankscrap::NotMoneyObjectError)
       end
     end
   end


### PR DESCRIPTION
## Changelog
- `Bank#initialize` now only takes one argument: a hash with credentials
- Bank adapters now define their required credentials as a constant
- Bank adapters are now forced to implement a `login` method that will be automatically called by `Bank#initialize`
- Config for proxy, log and debug mode has been extracted from `Bank` into the `Bankscrap` module
- Added rspec and first specs for testing the new configuration variables (finally we have some tests 🎉 )

## Background
One of the things I never liked about the current implementation was how we handle the differences between the required credentials for each bank. As you know, besides a username and a password, some banks require an ID, others require a company code. 

For this we had the `extra_args` option passed to the constructor of `Bank`, but this, despite of being an awful variable naming, didn't provide any information to users of the Ruby API about what credentials were required for each bank.

In addition to this we were passing two additional arguments to the bank constructor: `log` and `debug`. That should be responsible of the `Bankscrap` module and not of the `Bank` instance.

---

### Before:
**Ruby:**
```ruby
bbva = Bankscrap::BBVANetCash::Bank.new(
  USER, 
  PASSWORD, 
  extra_args: {company_code: COMPANY_CODE}, 
  debug: true, 
  log: true)
```

**CLI:**

    $ bankscrap transactions YourBank --user YOUR_BANK --password YOUR_PASSWORD

---

### After:
**Ruby:**

```ruby
Bankscrap.debug = true
Bankscrap.log = true
bbva = Bankscrap::BBVANetCash::Bank.new(
  user: USER, 
  password: PASSWORD, 
  company_code: COMPANY_CODE)
```

You can also define **ENV vars for any bank adapter** and omit the hash credentials:
````
export BANKSCRAP_MY_BANK_USER=YOUR_BANK_USER
export BANKSCRAP_MY_BANK_PASSWORD=YOUR_BANK_PASSWORD
```

```ruby
my_bank = Bankscrap::MyBank::Bank.new
```

**CLI:**

    $ bankscrap balance YourBank --credentials=user:YOUR_USER password:YOUR_PASSWORD

In addition you can check the required arguments for any bank adapter like this:

```ruby
Bankscrap::BBVANetCash::Bank::REQUIRED_CREDENTIALS
 => [:user, :password, :company_code]
```

---

As this is a **breaking change** of the library's API we should bump the version to `v2.0.0`. This change will require updating all the adapters to support the new API. I'll create PR for them soon.