### PR TITLE
Improve CLI output for transactions: added header and balance

### DIFF
--- a/lib/bankscrap/cli.rb
+++ b/lib/bankscrap/cli.rb
@@ -58,9 +58,8 @@ module Bankscrap
       export_to_file(transactions, options[:format], options[:output]) if options[:format]
 
       say "Transactions for: #{account.description} (#{account.iban})", :cyan
-      transactions.each do |transaction|
-        say transaction.to_s, (transaction.amount > Money.new(0) ? :green : :red)
-      end
+      print_transactions_header
+      transactions.each { |t|  print_transaction(t) }
     end
 
 
@@ -110,6 +109,23 @@ module Bankscrap
         say 'Sorry, file format not supported.', :red
         exit
       end
+    end
+
+    def print_transactions_header
+      say "\n"
+      say "DATE".ljust(13)
+      say "DESCRIPTION".ljust(50) + "\s\s\s"
+      say "AMOUNT".rjust(15) + "\s\s\s"
+      say "BALANCE".rjust(15)
+      say "-" * 99 
+    end
+
+    def print_transaction(transaction)
+      color = (transaction.amount > Money.new(0) ? :green : :red)
+      say transaction.effective_date.strftime('%d/%m/%Y') + "\s\s\s"
+      say transaction.description.squish.truncate(50).ljust(50) + "\s\s\s", color
+      say transaction.amount.format.rjust(15) + "\s\s\s", color
+      say transaction.balance.format.rjust(15)
     end
   end
 end

--- a/lib/bankscrap/transaction.rb
+++ b/lib/bankscrap/transaction.rb
@@ -12,7 +12,7 @@ module Bankscrap
     end
 
     def to_s
-      "#{effective_date.strftime('%d/%m/%Y')}   #{description.ljust(45)} #{amount.format.rjust(20)}"
+      description
     end
 
     def to_a


### PR DESCRIPTION
Some improvements for the CLI output of the transactions command:

* Moved logic to format trasanctions output from model to the CLI module.
* Added row with headers
* Added balance column
* Removed double whitespaces on transactions' descriptions using `squish`.
* Date is now printed in the default color and not in red or green.

## Before:
![before](https://cloud.githubusercontent.com/assets/855995/16115001/a6a0f7e0-33c4-11e6-9cd6-ef3834d1e9b5.png)


## After:
![after](https://cloud.githubusercontent.com/assets/855995/16115005/aa703188-33c4-11e6-8b41-1b5e648fb606.png)
