### PR TITLE
Fix CLI coloring on banks with currencies

### DIFF
--- a/lib/bankscrap/cli.rb
+++ b/lib/bankscrap/cli.rb
@@ -119,7 +119,7 @@ module Bankscrap
     end
 
     def print_transaction(transaction)
-      color = (transaction.amount > Money.new(0) ? :green : :red)
+      color = (transaction.amount.to_i > 0 ? :green : :red)
       say transaction.effective_date.strftime('%d/%m/%Y') + '   '
       say transaction.description.squish.truncate(50).ljust(50) + '   ', color
       say transaction.amount.format.rjust(15) + '   ', color


### PR DESCRIPTION
Transactions might have Money objects with currencies (see https://github.com/bankscrap/bankscrap-openbank/pull/1), but those fail when comparing to a currencyless Money object.

This gets just the numeric value from Object to check if it's positive or negative.