### PR TITLE
Add description_detail to Bankscrap::Transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.6
+
+- Added `:description_detail` field to Bankscrap::Transaction to store secondary description for a transaction
+provided by some banks.
+
 ## 2.0.5
 
 - Added `:raw_data` field to Bankscrap::Account class to store all the raw data for an account retrieved by a bank API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `:description_detail` field to Bankscrap::Transaction to store secondary description for a transaction
 provided by some banks.
+- Addded `:id` and `:description_detail` to the CSV exporter.
 
 ## 2.0.5
 

--- a/generators/templates/lib/bankscrap/%bank_name_dasherized%/bank.rb.tt
+++ b/generators/templates/lib/bankscrap/%bank_name_dasherized%/bank.rb.tt
@@ -75,6 +75,7 @@ module Bankscrap
           id: REPLACE_ME,
           amount: REPLACE_ME, # Should be a Money object
           description: REPLACE_ME,
+          description_detail: REPLACE_ME, # Optional
           effective_date: REPLACE_ME,
           operation_date: REPLACE_ME,
           balance: REPLACE_ME  # Should be a Money object

--- a/lib/bankscrap/exporters/csv.rb
+++ b/lib/bankscrap/exporters/csv.rb
@@ -3,7 +3,7 @@ require 'csv'
 module BankScrap
   module Exporter
     class Csv
-      HEADERS = %w(Date Description Amount).freeze
+      HEADERS = %w(ID Date Description DescriptionDetails Amount).freeze
 
       def initialize(output = nil)
         @output = output || 'transactions.csv'

--- a/lib/bankscrap/exporters/csv.rb
+++ b/lib/bankscrap/exporters/csv.rb
@@ -3,7 +3,7 @@ require 'csv'
 module BankScrap
   module Exporter
     class Csv
-      HEADERS = %w(ID Date Description DescriptionDetails Amount).freeze
+      HEADERS = %w(ID Date Description DescriptionDetail Amount).freeze
 
       def initialize(output = nil)
         @output = output || 'transactions.csv'

--- a/lib/bankscrap/transaction.rb
+++ b/lib/bankscrap/transaction.rb
@@ -15,7 +15,7 @@ module Bankscrap
     end
 
     def to_a
-      [effective_date.strftime('%d/%m/%Y'), description, amount]
+      [:id, effective_date.strftime('%d/%m/%Y'), description, description_details, amount]
     end
 
     def currency

--- a/lib/bankscrap/transaction.rb
+++ b/lib/bankscrap/transaction.rb
@@ -15,7 +15,7 @@ module Bankscrap
     end
 
     def to_a
-      [:id, effective_date.strftime('%d/%m/%Y'), description, description_details, amount]
+      [:id, effective_date.strftime('%d/%m/%Y'), description, description_detail, amount]
     end
 
     def currency

--- a/lib/bankscrap/transaction.rb
+++ b/lib/bankscrap/transaction.rb
@@ -15,7 +15,7 @@ module Bankscrap
     end
 
     def to_a
-      [:id, effective_date.strftime('%d/%m/%Y'), description, description_detail, amount]
+      [id, effective_date.strftime('%d/%m/%Y'), description, description_detail, amount]
     end
 
     def currency

--- a/lib/bankscrap/transaction.rb
+++ b/lib/bankscrap/transaction.rb
@@ -2,7 +2,7 @@ module Bankscrap
   class Transaction
     include Utils::Inspectable
 
-    attr_accessor :id, :amount, :description, :effective_date, :operation_date, :balance, :account
+    attr_accessor :id, :amount, :description, :description_detail, :effective_date, :operation_date, :balance, :account
 
     def initialize(params = {})
       raise NotMoneyObjectError.new(:amount) unless params[:amount].is_a?(Money)

--- a/lib/bankscrap/version.rb
+++ b/lib/bankscrap/version.rb
@@ -1,3 +1,3 @@
 module Bankscrap
-  VERSION = '2.0.5'.freeze
+  VERSION = '2.0.6'.freeze
 end


### PR DESCRIPTION
Some banks return information for a given transaction into two fields. For instance, Sabadell may return a JSON like this:

```json
{
  "date": "14-10-2017",
  "concept": "IMPUESTOS",
  "amount": {
    "value": "-1.000,00",
    "currency": "EUR"
  },
  "canSplit": true,
  "cardNumber": "",
  "balance": {
    "value": "[REDACTED]",
    "currency": "EUR"
  },
  "existDocument": false,
  "apuntNumber": "[REDACTED]",
  "productCode": "0",
  "valueDate": "14-10-2017",
  "conceptCode": "15",
  "conceptDetail": "NÓMINAS - SEGUROS SOCIALES",
  "timeStamp": "[REDACTED]",
  "referencor": "[REDACTED]",
  "sessionDate": "[REDACTED]",
  "returnBillCode": "",
  "numPAN": ""
}
```

The bankscrap-sabadell adapter is only taking `concept` and storing into the `description` attribute of the `Bankscrap::Transaction` object, however the `conceptDetail` is also needed to find out what kind of taxes (_IMPUESTOS_) is the transaction for.

This PR adds a new `description_detail` field to `Bankscrap::Transaction` to store this kind of data.